### PR TITLE
fix(roles-ui): truncate long role descriptions in table to prevent ho…

### DIFF
--- a/src/features/dashboard/pages/Admin/pages/Roles/Roles.jsx
+++ b/src/features/dashboard/pages/Admin/pages/Roles/Roles.jsx
@@ -28,6 +28,19 @@ const normalizeRoleName = (value = "") =>
 const isProtectedRole = (roleName = "") =>
   PROTECTED_SYSTEM_ROLES.has(normalizeRoleName(roleName));
 
+const renderTruncatedDescription = (value) => {
+  const description = value || "-";
+
+  return (
+    <span
+      className="block max-w-[520px] truncate"
+      title={description}
+    >
+      {description}
+    </span>
+  );
+};
+
 const Roles = () => {
   const { roles, pagination, fetchRoles, createRole, updateRole, deleteRole } =
     useRoles();
@@ -165,6 +178,12 @@ const Roles = () => {
             data: paginatedData,
             dataPropertys: ["name", "description"],
             state: false,
+            customRenderers: {
+              description: renderTruncatedDescription,
+            },
+            cellClassNames: {
+              description: "max-w-[520px]",
+            },
           }}
           onEdit={hasPermission("roles", "Editar") ? handleEdit : null}
           onDelete={hasPermission("roles", "Eliminar") ? handleDelete : null}


### PR DESCRIPTION
…rizontal overflow

- Add truncated renderer for role description with ellipsis
- Keep full description accessible via tooltip (title)
- Limit description cell width for consistent table layout