### PR TITLE
fix(prod): stabilize help preview and keep session after hard reload

### DIFF
--- a/src/features/dashboard/pages/Admin/pages/Athletes/Payments/services/PaymentsService.js
+++ b/src/features/dashboard/pages/Admin/pages/Athletes/Payments/services/PaymentsService.js
@@ -357,8 +357,7 @@ return this.handleError(error);
       });
       
       // Usar el endpoint correcto del backend: /history/report
-      const response = await apiClient.get(`${this.endpoint}/history/report`, { params: queryParams });
-      const payload = response?.data;
+      const payload = await apiClient.get(`${this.endpoint}/history/report`, { params: queryParams });
 
       return {
         success: payload?.success ?? true,

--- a/src/features/dashboard/pages/Admin/pages/OnlineHelp/components/VideoPlaceholder.jsx
+++ b/src/features/dashboard/pages/Admin/pages/OnlineHelp/components/VideoPlaceholder.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { FaExternalLinkAlt, FaPlayCircle } from "react-icons/fa";
 
 const getDriveFileId = (url = "") => {
@@ -17,40 +18,88 @@ const getEmbeddableUrl = (url = "") => {
   return String(url).trim();
 };
 
+const getDriveStreamUrl = (fileId = "") =>
+  `https://drive.google.com/uc?export=download&id=${fileId}`;
+
 const isDirectVideoFile = (url = "") =>
   /\.(mp4|webm|ogg)(\?.*)?$/i.test(String(url).trim());
 
-const VideoPlaceholder = ({ hasVideo, videoUrl, title }) => {
-  if (hasVideo) {
-    const embedUrl = getEmbeddableUrl(videoUrl);
-    const renderAsIframe = embedUrl.startsWith("https://drive.google.com/file/d/");
+const buildPreviewConfig = (url = "") => {
+  const cleanUrl = String(url).trim();
+  if (!cleanUrl) {
+    return {
+      type: "none",
+      openUrl: "",
+    };
+  }
 
+  const driveId = getDriveFileId(cleanUrl);
+  if (driveId) {
+    return {
+      type: "drive",
+      openUrl: cleanUrl,
+      embedUrl: getEmbeddableUrl(cleanUrl),
+      streamUrl: getDriveStreamUrl(driveId),
+    };
+  }
+
+  if (isDirectVideoFile(cleanUrl)) {
+    return {
+      type: "video",
+      openUrl: cleanUrl,
+      streamUrl: cleanUrl,
+    };
+  }
+
+  return {
+    type: "iframe",
+    openUrl: cleanUrl,
+    embedUrl: cleanUrl,
+  };
+};
+
+const VideoPlaceholder = ({ hasVideo, videoUrl, title }) => {
+  const previewConfig = useMemo(() => buildPreviewConfig(videoUrl), [videoUrl]);
+  const [useFallbackPreview, setUseFallbackPreview] = useState(false);
+
+  useEffect(() => {
+    setUseFallbackPreview(false);
+  }, [previewConfig.openUrl]);
+
+  if (hasVideo) {
     return (
       <div className="rounded-xl border border-primary-purple/20 bg-primary-purple/5 p-4">
         <p className="text-sm text-slate-700 mb-3">
           Video listo para esta ayuda.
         </p>
 
-        {renderAsIframe ? (
-          <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-100 h-52 sm:h-56">
-            <iframe
-              src={embedUrl}
-              title={title}
-              className="absolute inset-x-0 -top-8 w-full h-[calc(100%+64px)] border-0"
-              allow="autoplay"
-              allowFullScreen
-            />
-          </div>
-        ) : isDirectVideoFile(embedUrl) ? (
+        {(previewConfig.type === "drive" || previewConfig.type === "video") &&
+        !useFallbackPreview ? (
           <video
             className="w-full rounded-xl border border-slate-200 bg-black"
             controls
             preload="metadata"
-            src={embedUrl}
+            src={previewConfig.streamUrl}
+            onError={() => setUseFallbackPreview(true)}
           >
             Tu navegador no soporta reproducción de video.
           </video>
-        ) : null}
+        ) : previewConfig.type === "iframe" ? (
+          <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-slate-100 h-52 sm:h-56">
+            <iframe
+              src={previewConfig.embedUrl}
+              title={title}
+              className="absolute inset-0 w-full h-full border-0"
+              allow="autoplay"
+              allowFullScreen
+            />
+          </div>
+        ) : (
+          <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600">
+            La vista previa no está disponible en este navegador. Usa el botón
+            para abrir el video.
+          </div>
+        )}
 
         <div className="mt-3">
           <a


### PR DESCRIPTION
Frontend: improve Online Help video preview fallback so blocked embedded providers no longer break the preview UX.

Backend: unify refresh token cookie options and use cross-site safe settings in production (SameSite=None + Secure) to preserve auth on Ctrl+R.

Also align clearCookie options with cookie creation options to avoid stale refresh-token behavior.